### PR TITLE
Adding support for EN25QH128 Flash chip

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,3 +2,10 @@
 
 ## Scripts:
 Compile_ *** => compiles a Version for a specific Device
+
+## Build using a ubuntu container
+1) Checkout the repo
+2) `docker run -it -v d:<location>:/uboot ubuntu /bin/bash`
+3) `apt-get update && apt-get upgrade && apt-get install -y build-essential make git`
+4) `git clone https://github.com/Dafang-Hacks/mips-gcc472-glibc216-64bit.git toolchain`
+5) `cd /uboot && ./Compile_*`

--- a/drivers/spi/jz_spi.h
+++ b/drivers/spi/jz_spi.h
@@ -348,6 +348,27 @@ static struct jz_spi_support jz_spi_support_table[] = {
 #endif
 		},
 	},
+	{
+		.name           = "EN25QH128",
+		.id_manufactory = 0x1c7018,
+		.page_size       = 256,
+		.sector_size      = (64 * 1024),
+		.addr_size = 3,
+		.size           = (16 * 1024 * 1024),
+		.quad_mode = {
+			.dummy_byte = 8,
+			.RDSR_CMD = CMD_RDSR_1,
+			.WRSR_CMD = CMD_WRSR_1,
+			.RDSR_DATE = 0x2,//the data is write the spi status register for QE bit
+			.RD_DATE_SIZE = 1,
+			.WRSR_DATE = 0x2,//this bit should be the flash QUAD mode enable
+			.WD_DATE_SIZE = 1,
+			.cmd_read = CMD_QUAD_READ,
+#ifdef CONFIG_JZ_SFC
+			.sfc_mode = TRAN_SPI_QUAD,
+#endif
+		},
+	},
 };
 
 #endif /* __JZ_SPI_H__ */


### PR DESCRIPTION
As discussed on https://github.com/Dafang-Hacks/uboot/issues/8
I have added support for EN25QH128 flash chip

After the change, U-Boot shows the correct IC
```
Now running in RAM - U-Boot at: 83f94000
MMC:   msc: 0
the manufacturer 1c
SF: Detected EN25QH128
```